### PR TITLE
Refactor TimetableMonitor

### DIFF
--- a/fleet_management/config/builder.py
+++ b/fleet_management/config/builder.py
@@ -6,7 +6,7 @@ from fleet_management.resources.infrastructure.brsu import DurationGraph
 from fmlib.config.builders import Store
 from mrs.allocation.auctioneer import Auctioneer
 from fleet_management.plugins.mrta.bidder import Bidder
-from fleet_management.plugins.mrta.timetable_monitor import TimetableMonitor
+from fleet_management.plugins.mrta.timetable_monitor import TimetableMonitor, TimetableMonitorProxy
 from fleet_management.plugins.mrta.schedule_execution_monitor import ScheduleExecutionMonitor
 from mrs.config.builder import MRTABuilder, DelayRecovery, PerformanceTracker, Scheduler
 from mrs.timetable.timetable import Timetable, TimetableManager
@@ -113,6 +113,7 @@ class RobotBuilder:
 robot_proxy_builder = RobotBuilder()
 robot_proxy_builder.register_component_module('timetable', Timetable)
 robot_proxy_builder.register_component_module('bidder', Bidder)
+robot_proxy_builder.register_component_module('timetable_monitor', TimetableMonitorProxy)
 
 robot_builder = RobotBuilder(proxy=False)
 robot_builder.register_component_module('timetable', Timetable)

--- a/fleet_management/config/default/config.yaml
+++ b/fleet_management/config/default/config.yaml
@@ -133,9 +133,9 @@ robot_proxy:
         - msg_type: 'ROBOT-POSE'
           component: '.robot_pose_cb'
         - msg_type: 'REMOVE-TASK-FROM-SCHEDULE'
-          component: '.remove_task_cb'
+          component: 'timetable_monitor.remove_task_cb'
         - msg_type: 'TASK-STATUS'
-          component: '.task_status_cb'
+          component: 'timetable_monitor.task_status_cb'
 
 robot:
   scheduler:

--- a/fleet_management/plugins/mrta/robot.py
+++ b/fleet_management/plugins/mrta/robot.py
@@ -1,8 +1,7 @@
 import argparse
-import time
 import logging
+
 from fleet_management.config.loader import Configurator
-from fmlib.models.tasks import TransportationTask as Task
 
 
 class Robot:
@@ -20,10 +19,7 @@ class Robot:
         try:
             self.api.start()
             while True:
-                tasks = Task.get_tasks_by_robot(self.robot_id)
-                if self.schedule_execution_monitor.task is None:
-                    self.schedule_execution_monitor.process_tasks(tasks)
-                time.sleep(0.5)
+                self.schedule_execution_monitor.run()
         except (KeyboardInterrupt, SystemExit):
             self.logger.info("Terminating %s robot ...", self.robot_id)
             self.api.shutdown()

--- a/fleet_management/plugins/mrta/schedule_execution_monitor.py
+++ b/fleet_management/plugins/mrta/schedule_execution_monitor.py
@@ -1,35 +1,20 @@
 from fmlib.models.tasks import TransportationTask as Task
-from fmlib.utils.messages import Document, Message
 from mrs.execution.schedule_execution_monitor import ScheduleExecutionMonitor as ScheduleExecutionMonitorBase
-from mrs.messages.task_status import TaskStatus, TaskProgress
 from ropod.structs.status import TaskStatus as TaskStatusConst
-from ropod.utils.timestamp import TimeStamp
 
 
 class ScheduleExecutionMonitor(ScheduleExecutionMonitorBase):
     def __init__(self, robot_id, timetable, scheduler, delay_recovery, **kwargs):
         super().__init__(robot_id, timetable, scheduler, delay_recovery, **kwargs)
 
-    def task_status_cb(self, msg):
-        message = Message(**msg)
-        payload = Document.from_payload(message.payload)
-        task_progress = payload.get("task_progress")
-        if task_progress:
-            task_progress = TaskProgress.from_dict(task_progress)
-            payload.update(task_progress=task_progress)
-
-        task_status = TaskStatus(**payload)
-        timestamp = TimeStamp.from_str(message.timestamp).to_datetime()
-
+    def process_task_status(self, task_status, timestamp):
         if self.robot_id == task_status.robot_id:
-
             task = Task.get_task(task_status.task_id)
-            self.logger.debug("Received task status %s for task %s", task_status.task_status, task.task_id)
 
             if task_status.task_status == TaskStatusConst.ONGOING:
-                self.update_timetable(task, task_status.task_progress, timestamp)
+                self.update_timetable(task, task_status.robot_id, task_status.task_progress, timestamp)
 
-            elif task_status.task_status == TaskStatusConst.COMPLETED:
+            if task_status.task_status == TaskStatusConst.COMPLETED:
                 self.logger.debug("Completing execution of task %s", task.task_id)
                 self.task = None
 

--- a/fleet_management/proxies/robot.py
+++ b/fleet_management/proxies/robot.py
@@ -2,27 +2,20 @@ import argparse
 import logging
 import time
 
-from mrs.messages.task_status import TaskStatus, TaskProgress
-from ropod.utils.timestamp import TimeStamp
-
 from fleet_management.config.loader import Configurator
 from fleet_management.db.models.robot import Ropod
 from fmlib.models.tasks import TransportationTask as Task
-from mrs.messages.remove_task import RemoveTaskFromSchedule
-from mrs.utils.time import relative_to_ztp
-from ropod.structs.status import TaskStatus as TaskStatusConst, ActionStatus as ActionStatusConst
-from stn.exceptions.stp import NoSTPSolution
-from fmlib.utils.messages import Document, Message
+from ropod.structs.status import TaskStatus as TaskStatusConst
 
 
 class RobotProxy(object):
-    def __init__(self, robot_id, bidder, timetable, **kwargs):
+    def __init__(self, robot_id, bidder, timetable_monitor, **kwargs):
         self.logger = logging.getLogger('fms.robot.proxy%s' % robot_id)
 
         self.robot_id = robot_id
         self.bidder = bidder
+        self.timetable_monitor = timetable_monitor
         self.robot = Ropod.create_new(robot_id)
-        self.timetable = timetable
 
         self.api = kwargs.get('api')
         if self.api:
@@ -48,12 +41,6 @@ class RobotProxy(object):
         if robot_id == self.robot_id:
             self.robot.update_position(subarea=payload.get('subarea'), **payload.get('pose'))
 
-    def remove_task_cb(self, msg):
-        payload = msg['payload']
-        remove_task = RemoveTaskFromSchedule.from_payload(payload)
-        task = Task.get_task(remove_task.task_id)
-        self._remove_task(task, remove_task.status)
-
     def task_cb(self, msg):
         payload = msg['payload']
         assigned_robots = payload.get("assignedRobots")
@@ -62,107 +49,6 @@ class RobotProxy(object):
             self.logger.debug("Received task %s", task_id)
             task = Task.get_task(task_id)
             task.update_status(TaskStatusConst.DISPATCHED)
-
-    def task_status_cb(self, msg):
-        message = Message(**msg)
-        payload = Document.from_payload(message.payload)
-        task_progress = payload.get("task_progress")
-        if task_progress:
-            task_progress = TaskProgress.from_dict(task_progress)
-            payload.update(task_progress=task_progress)
-
-        task_status = TaskStatus(**payload)
-        timestamp = TimeStamp.from_str(message.timestamp).to_datetime()
-
-        if self.robot_id == task_status.robot_id:
-            task = Task.get_task(task_status.task_id)
-            self.logger.debug("Received task status %s for task %s", task_status.task_status, task.task_id)
-
-            if task_status.task_status == TaskStatusConst.ONGOING and task_progress:
-                self._update_timetable(task, task_status.task_progress, timestamp)
-                task.update_status(task_status.task_status)
-
-    def _update_timetable(self, task, task_progress, timestamp):
-        self.logger.debug("Updating timetable")
-
-        r_assigned_time = relative_to_ztp(self.timetable.ztp, timestamp)
-        first_action_id = task.plan[0].actions[0].action_id
-
-        if task_progress.action_id == first_action_id and \
-                task_progress.action_status.status == ActionStatusConst.ONGOING:
-            node_id, node = self.timetable.stn.get_node_by_type(task.task_id, 'start')
-            self._update_timepoint(task, r_assigned_time, node_id)
-        else:
-            # An action could be associated to two nodes, e.g., between pickup and delivery there is only one action
-            nodes = self.timetable.stn.get_nodes_by_action(task_progress.action_id)
-
-            for node_id, node in nodes:
-                if (node.node_type == 'pickup' and
-                    task_progress.action_status.status == ActionStatusConst.ONGOING) or \
-                        (node.node_type == 'delivery' and
-                         task_progress.action_status.status == ActionStatusConst.COMPLETED):
-                    self._update_timepoint(task, r_assigned_time, node_id)
-
-    def _update_timepoint(self, task, r_assigned_time, node_id):
-        self.timetable.update_timepoint(r_assigned_time, node_id)
-
-        nodes = self.timetable.stn.get_nodes_by_task(task.task_id)
-        self._update_edge('start', 'pickup', nodes)
-        self._update_edge('pickup', 'delivery', nodes)
-        self.bidder.changed_timetable = True
-
-        self.logger.debug("Updated stn: \n %s ", self.timetable.stn)
-        self.logger.debug("Updated dispatchable graph: \n %s", self.timetable.dispatchable_graph)
-
-    def _update_edge(self, start_node, finish_node, nodes):
-        node_ids = [node_id for node_id, node in nodes if (node.node_type == start_node and node.is_executed) or
-                    (node.node_type == finish_node and node.is_executed)]
-        if len(node_ids) == 2:
-            self.timetable.execute_edge(node_ids[0], node_ids[1])
-
-    def _remove_task(self, task, status):
-        self.logger.debug("Deleting task %s from timetable and changing its status to %s", task.task_id, status)
-        next_task = self.timetable.get_next_task(task)
-
-        if status == TaskStatusConst.COMPLETED:
-            if next_task:
-                finish_current_task = self.timetable.stn.get_time(task.task_id, 'delivery', False)
-                self.timetable.stn.assign_earliest_time(finish_current_task, next_task.task_id, 'start', force=True)
-            self.timetable.remove_task(task.task_id)
-
-        else:
-            prev_task = self.timetable.get_previous_task(task)
-            self.timetable.remove_task(task.task_id)
-            if prev_task and next_task:
-                self.update_pre_task_constraint(next_task)
-
-        task.update_status(status)
-        self.logger.debug("STN: %s", self.timetable.stn)
-        self.logger.debug("Dispatchable Graph: %s", self.timetable.dispatchable_graph)
-        self._re_compute_dispatchable_graph()
-
-    def _re_compute_dispatchable_graph(self):
-        if self.timetable.stn.is_empty():
-            self.logger.warning("Timetable of robot %s is empty", self.robot_id)
-            return
-        self.logger.debug("Recomputing dispatchable graph of robot %s", self.timetable.robot_id)
-        try:
-            self.timetable.dispatchable_graph = self.timetable.compute_dispatchable_graph(self.timetable.stn)
-            self.logger.debug("Dispatchable graph robot %s: %s", self.timetable.robot_id, self.timetable.dispatchable_graph)
-            self.bidder.changed_timetable = True
-        except NoSTPSolution:
-            self.logger.warning("Temporal network is inconsistent")
-
-    def update_pre_task_constraint(self, next_task):
-        self.logger.debug("Update pre_task constraint of task %s", next_task.task_id)
-        position = self.timetable.get_task_position(next_task.task_id)
-        prev_location = self.bidder.get_previous_location(position)
-        travel_duration = self.bidder.get_travel_duration(next_task, prev_location)
-
-        stn_task = self.timetable.get_stn_task(next_task.task_id)
-        stn_task.update_edge("travel_time", travel_duration.mean, travel_duration.variance)
-        self.timetable.add_stn_task(stn_task)
-        self.timetable.update_task(stn_task)
 
     def run(self):
         try:

--- a/fleet_management/task/dispatcher.py
+++ b/fleet_management/task/dispatcher.py
@@ -92,7 +92,7 @@ class Dispatcher:
 
     def send_d_graph_update(self, timetable):
         prev_d_graph_update = self.d_graph_updates.get(timetable.robot_id)
-        d_graph_update = timetable.get_d_graph_update(self.n_queued_tasks)
+        d_graph_update = timetable.get_d_graph_update(timetable.robot_id, self.n_queued_tasks)
 
         if prev_d_graph_update != d_graph_update:
             self.logger.debug("Sending DGraphUpdate to %s", timetable.robot_id)

--- a/fleet_management/task/monitor.py
+++ b/fleet_management/task/monitor.py
@@ -51,8 +51,7 @@ class TaskMonitor:
         robot_id = payload.get("robot_id")
         timestamp = TimeStamp.from_str(message.timestamp)
 
-        self.logger.debug("Received task status message for task %s by %s", task_id, robot_id)
-        self._update_task_status(task_id, status, robot_id)
+        self.logger.debug("Received task status %s message for task %s by %s", status, task_id, robot_id)
 
         failure_warning = ''
         if status == TaskStatus.FAILED:
@@ -79,6 +78,8 @@ class TaskMonitor:
         # Notify the user if there is a need for recovery actions from them
         if failure_warning:
             self.request_human_assistance(failure_warning, robot_id, task_progress.get("area"))
+
+        self._update_task_status(task_id, status, robot_id)
 
     def request_human_assistance(self, reason, robot_id, location):
         from fmlib.utils.messages import Header


### PR DESCRIPTION
TimetableMonitors in fms import from new TimetableMonitors in mrta, which inherit from a TimetableMonitor base
Add TimetableMonitor to RobotProxy

Requires:
- https://github.com/ropod-project/mrta/pull/109
- https://github.com/ropod-project/mrta_stn/pull/43
- https://github.com/ropod-project/fmlib/pull/1